### PR TITLE
chore: dedup set-resolution helpers, remove redundant test fixtures

### DIFF
--- a/src/envbool/_config.py
+++ b/src/envbool/_config.py
@@ -265,7 +265,8 @@ def _parse_config(data: dict, path: Path) -> EnvBoolConfig:
     (e.g. strict = "yes" instead of strict = true) raise ConfigError with a message
     that names the expected type, since a type mismatch is almost certainly a typo.
 
-    The extend/replace logic here mirrors _resolve() in core.py:
+    The extend/replace logic here is shared with _resolve() in _core.py via
+    _apply_replace_or_extend():
       - "truthy" replaces DEFAULT_TRUTHY entirely
       - "extend_truthy" adds to DEFAULT_TRUTHY
       - "truthy" takes priority when both present (ruff's select/extend-select pattern)
@@ -284,26 +285,25 @@ def _parse_config(data: dict, path: Path) -> EnvBoolConfig:
     strict = _get_bool_field(data, "strict", path)
     warn = _get_bool_field(data, "warn", path)
 
+    # Imported lazily (not at module level) because _core.py imports
+    # _get_config from this module at load time -- a top-level import here
+    # would create a circular import.
+    from envbool._core import _apply_replace_or_extend  # noqa: PLC0415
+
     # --- set fields: apply extend/replace logic ---
     # truthy replaces DEFAULT_TRUTHY; extend_truthy adds to it; truthy wins if both.
     raw_truthy = _get_str_list_field(data, "truthy", path)
     raw_extend_truthy = _get_str_list_field(data, "extend_truthy", path)
-    if raw_truthy is not None:
-        effective_truthy = _normalize_set(raw_truthy)
-    elif raw_extend_truthy is not None:
-        effective_truthy = DEFAULT_TRUTHY | _normalize_set(raw_extend_truthy)
-    else:
-        effective_truthy = DEFAULT_TRUTHY
+    effective_truthy = _apply_replace_or_extend(
+        DEFAULT_TRUTHY, raw_truthy, raw_extend_truthy
+    )
 
     # Same extend/replace logic for the falsy side, independent of truthy.
     raw_falsy = _get_str_list_field(data, "falsy", path)
     raw_extend_falsy = _get_str_list_field(data, "extend_falsy", path)
-    if raw_falsy is not None:
-        effective_falsy = _normalize_set(raw_falsy)
-    elif raw_extend_falsy is not None:
-        effective_falsy = DEFAULT_FALSY | _normalize_set(raw_extend_falsy)
-    else:
-        effective_falsy = DEFAULT_FALSY
+    effective_falsy = _apply_replace_or_extend(
+        DEFAULT_FALSY, raw_falsy, raw_extend_falsy
+    )
 
     _logger.debug(
         "Config loaded from %s: strict=%s warn=%s truthy=%s falsy=%s",
@@ -321,11 +321,6 @@ def _parse_config(data: dict, path: Path) -> EnvBoolConfig:
         effective_falsy=effective_falsy,
         source_path=path,
     )
-
-
-def _normalize_set(values: list[str]) -> frozenset[str]:
-    """Strip and lowercase values so they match to_bool()'s normalized input."""
-    return frozenset(v.strip().lower() for v in values)
 
 
 def _get_bool_field(data: dict, key: str, path: Path) -> bool | None:

--- a/src/envbool/_core.py
+++ b/src/envbool/_core.py
@@ -145,6 +145,36 @@ def _normalize_set(values: Iterable[str]) -> frozenset[str]:
     return frozenset(v.strip().lower() for v in values)
 
 
+def _apply_replace_or_extend(
+    base: frozenset[str],
+    replace: Iterable[str] | None,
+    extend: Iterable[str] | None,
+) -> frozenset[str]:
+    """Resolve a value set using replace/extend/fall-back-to-base precedence.
+
+    Shared by _resolve() (call-site truthy/falsy args) and _config.py's
+    _parse_config() (TOML truthy/falsy keys) since both layer their inputs
+    on top of a base set using the same ruff select/extend-select pattern:
+        replace -- full replacement; caller owns the entire set
+        extend  -- additive; merges on top of base
+        neither -- use base as-is
+    replace takes precedence over extend; both cannot apply at once.
+
+    Args:
+        base: The starting set to fall back to or extend.
+        replace: If not None, fully replaces base (normalized).
+        extend: If not None and replace is None, merged on top of base.
+
+    Returns:
+        The resolved, normalized frozenset.
+    """
+    if replace is not None:
+        return _normalize_set(replace)
+    if extend is not None:
+        return base | _normalize_set(extend)
+    return base
+
+
 def _resolve(
     *,
     config_truthy: frozenset[str] = DEFAULT_TRUTHY,
@@ -154,24 +184,9 @@ def _resolve(
     extend_truthy: Iterable[str] | None = None,
     extend_falsy: Iterable[str] | None = None,
 ) -> tuple[frozenset[str], frozenset[str]]:
-    # Priority mirrors ruff's select/extend-select pattern:
-    #   truthy        -- full replacement; caller owns the entire set
-    #   extend_truthy -- additive; merges on top of config_truthy
-    #   (neither)     -- use config_truthy as-is (defaults when no config file)
-    # truthy takes precedence over extend_truthy; both cannot apply at once.
-    if truthy is not None:
-        effective_truthy = _normalize_set(truthy)
-    elif extend_truthy is not None:
-        effective_truthy = config_truthy | _normalize_set(extend_truthy)
-    else:
-        effective_truthy = config_truthy
-
-    # Same three-level logic for the falsy side, independent of truthy.
-    if falsy is not None:
-        effective_falsy = _normalize_set(falsy)
-    elif extend_falsy is not None:
-        effective_falsy = config_falsy | _normalize_set(extend_falsy)
-    else:
-        effective_falsy = config_falsy
+    # Priority mirrors ruff's select/extend-select pattern -- see
+    # _apply_replace_or_extend() docstring for the full precedence rules.
+    effective_truthy = _apply_replace_or_extend(config_truthy, truthy, extend_truthy)
+    effective_falsy = _apply_replace_or_extend(config_falsy, falsy, extend_falsy)
 
     return (effective_truthy, effective_falsy)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,13 +9,6 @@ from envbool._cli import main
 from envbool._config import _reset_config
 
 
-@pytest.fixture(autouse=True)
-def reset_config():
-    _reset_config()
-    yield
-    _reset_config()
-
-
 def run_cli(*args, monkeypatch, stdin_text=None, is_tty=True):
     """Invoke main() with controlled argv/stdin. Returns (stdout, stderr, exit_code)."""
     monkeypatch.setattr(sys, "argv", ["envbool", *args])

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -9,14 +9,6 @@ from envbool._defaults import DEFAULT_FALSY, DEFAULT_TRUTHY
 from envbool._env import envbool
 from envbool.exceptions import InvalidBoolValueError
 
-
-@pytest.fixture(autouse=True)
-def reset_config():
-    _reset_config()
-    yield
-    _reset_config()
-
-
 # ---------------------------------------------------------------------------
 # Unset / empty
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Extracted the duplicated `_normalize_set()` and the duplicated truthy/falsy replace/extend precedence logic (independently implemented in both `_core.py:_resolve()` and `_config.py:_parse_config()`) into a single shared `_apply_replace_or_extend()` helper in `_core.py`.
- Removed redundant local `reset_config()` fixtures in `test_env.py` and `test_cli.py` that duplicated the `autouse=True` fixture already in `conftest.py`.

Full project review found no dead code, no unused imports, no unreachable branches, and no other significant overcomplication — these were the only confirmed findings.

## Test plan
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `uv run ty check src/` — clean
- [x] `uv run pytest --cov=envbool --cov-report=term-missing` — 238 passed, 100% coverage maintained
- [x] No behavior change — all existing tests for `to_bool()`, `envbool()`, and config loading pass unmodified

🤖 Generated with [Claude Code](https://claude.com/claude-code)