### PR TITLE
feat: expose custom truthy/falsy value sets in CLI

### DIFF
--- a/src/envbool/_cli.py
+++ b/src/envbool/_cli.py
@@ -15,6 +15,10 @@ Exit codes:
 
 Omitting --strict defers to the config file setting (default: lenient).
 
+Value sets: --truthy/--falsy (repeatable) replace the truthy/falsy set;
+--extend-truthy/--extend-falsy (repeatable) add to it. Mirrors ruff's
+select/extend-select pattern.
+
 Public surface:
     main()  -- entry point registered as the "envbool" command
 """
@@ -75,6 +79,30 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help='Print "true" or "false" instead of using exit codes.',
     )
+    parser.add_argument(
+        "--truthy",
+        metavar="VALUE",
+        action="append",
+        help="Replace the truthy set with VALUE (repeatable).",
+    )
+    parser.add_argument(
+        "--falsy",
+        metavar="VALUE",
+        action="append",
+        help="Replace the falsy set with VALUE (repeatable).",
+    )
+    parser.add_argument(
+        "--extend-truthy",
+        metavar="VALUE",
+        action="append",
+        help="Add VALUE to the truthy set (repeatable).",
+    )
+    parser.add_argument(
+        "--extend-falsy",
+        metavar="VALUE",
+        action="append",
+        help="Add VALUE to the falsy set (repeatable).",
+    )
     return parser
 
 
@@ -90,11 +118,28 @@ def main() -> None:
     if args.value is not None and args.var is not None:
         parser.error("VAR_NAME and --value are mutually exclusive")
 
+    value_set_kwargs = {
+        "truthy": args.truthy,
+        "falsy": args.falsy,
+        "extend_truthy": args.extend_truthy,
+        "extend_falsy": args.extend_falsy,
+    }
+
     try:
         if args.value is not None:
-            result = to_bool(args.value, strict=args.strict, default=args.default)
+            result = to_bool(
+                args.value,
+                strict=args.strict,
+                default=args.default,
+                **value_set_kwargs,
+            )
         elif args.var is not None:
-            result = envbool(args.var, strict=args.strict, default=args.default)
+            result = envbool(
+                args.var,
+                strict=args.strict,
+                default=args.default,
+                **value_set_kwargs,
+            )
         elif not sys.stdin.isatty():
             # Non-TTY stdin means the user piped or redirected input. Strip surrounding
             # whitespace (handles the trailing newline echo adds) then reject anything
@@ -106,7 +151,12 @@ def main() -> None:
                     file=sys.stderr,
                 )
                 sys.exit(2)
-            result = to_bool(raw, strict=args.strict, default=args.default)
+            result = to_bool(
+                raw,
+                strict=args.strict,
+                default=args.default,
+                **value_set_kwargs,
+            )
         else:
             parser.print_usage(sys.stderr)
             sys.exit(2)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -204,3 +204,73 @@ class TestCLIConfigIntegration:
         monkeypatch.setenv("TEST_VAR", "enabled")
         code = run_cli("TEST_VAR", monkeypatch=monkeypatch)
         assert code == 0
+
+
+# ---------------------------------------------------------------------------
+# Custom truthy/falsy value sets (--truthy/--falsy/--extend-truthy/--extend-falsy)
+# ---------------------------------------------------------------------------
+
+
+class TestCLIValueSets:
+    def test_truthy_replaces_default_set(self, monkeypatch):
+        # "true" is a default truthy value but is excluded once --truthy replaces
+        # the set entirely, so it should now be treated as unrecognized (falsy).
+        monkeypatch.setenv("TEST_VAR", "true")
+        code = run_cli("TEST_VAR", "--truthy", "yes", monkeypatch=monkeypatch)
+        assert code == 1
+
+    def test_truthy_replace_recognizes_custom_value(self, monkeypatch):
+        monkeypatch.setenv("TEST_VAR", "yes")
+        code = run_cli("TEST_VAR", "--truthy", "yes", monkeypatch=monkeypatch)
+        assert code == 0
+
+    def test_falsy_replaces_default_set(self, monkeypatch):
+        monkeypatch.setenv("TEST_VAR", "off")
+        code = run_cli("TEST_VAR", "--falsy", "nope", monkeypatch=monkeypatch)
+        # "off" is no longer in the (replaced) falsy set and isn't truthy either,
+        # so lenient mode falls back to False -> exit 1.
+        assert code == 1
+
+    def test_extend_truthy_adds_to_defaults(self, monkeypatch):
+        monkeypatch.setenv("TEST_VAR", "enabled")
+        code = run_cli(
+            "TEST_VAR", "--extend-truthy", "enabled", monkeypatch=monkeypatch
+        )
+        assert code == 0
+
+    def test_extend_truthy_keeps_defaults(self, monkeypatch):
+        # Default truthy values still work alongside the extension.
+        monkeypatch.setenv("TEST_VAR", "true")
+        code = run_cli(
+            "TEST_VAR", "--extend-truthy", "enabled", monkeypatch=monkeypatch
+        )
+        assert code == 0
+
+    def test_extend_falsy_adds_to_defaults(self, monkeypatch):
+        monkeypatch.setenv("TEST_VAR", "nope")
+        code = run_cli("TEST_VAR", "--extend-falsy", "nope", monkeypatch=monkeypatch)
+        assert code == 1
+
+    def test_repeated_extend_truthy_accumulates(self, monkeypatch):
+        monkeypatch.setenv("TEST_VAR", "on2")
+        code = run_cli(
+            "TEST_VAR",
+            "--extend-truthy",
+            "on1",
+            "--extend-truthy",
+            "on2",
+            monkeypatch=monkeypatch,
+        )
+        assert code == 0
+
+    def test_combined_truthy_and_extend_falsy(self, monkeypatch):
+        monkeypatch.setenv("TEST_VAR", "nope")
+        code = run_cli(
+            "TEST_VAR",
+            "--truthy",
+            "yes",
+            "--extend-falsy",
+            "nope",
+            monkeypatch=monkeypatch,
+        )
+        assert code == 1


### PR DESCRIPTION
## Summary
- Adds `--truthy`, `--falsy`, `--extend-truthy`, `--extend-falsy` repeatable flags to the CLI, mirroring ruff's `select`/`extend-select` pattern
- Threads the existing `truthy`/`falsy`/`extend_truthy`/`extend_falsy` kwargs (already supported by `envbool()`/`to_bool()`) through all three CLI input paths (`--value`, `VAR_NAME`, stdin)
- No new validation logic — replace-wins-over-extend precedence is already handled by `_core._resolve()`

Closes #1.

## Test plan
- [x] `uv run pytest --cov=envbool` — 246 passed, 100% coverage
- [x] `uv run ruff check` / `ruff format --check` / `uv run ty check` all pass
- [x] Manual smoke test: `envbool MY_FLAG --extend-truthy enabled` and `--truthy yes --truthy enabled --print`

🤖 Generated with [Claude Code](https://claude.com/claude-code)