### PR TITLE
feat: add --show-config flag to print effective configuration

### DIFF
--- a/src/envbool/_cli.py
+++ b/src/envbool/_cli.py
@@ -19,6 +19,11 @@ Value sets: --truthy/--falsy (repeatable) replace the truthy/falsy set;
 --extend-truthy/--extend-falsy (repeatable) add to it. Mirrors ruff's
 select/extend-select pattern.
 
+--show-config prints the effective configuration (config file path, strict,
+warn, truthy, falsy) and exits. It can be combined with --strict/--truthy/
+--falsy/--extend-truthy/--extend-falsy to preview overrides, but is mutually
+exclusive with VAR_NAME, --value, --print, and --default.
+
 Public surface:
     main()  -- entry point registered as the "envbool" command
 """
@@ -31,7 +36,8 @@ __all__ = ["main"]
 import argparse
 import sys
 
-from envbool._core import to_bool
+from envbool._config import load_config
+from envbool._core import _resolve, to_bool
 from envbool._env import envbool
 from envbool.exceptions import InvalidBoolValueError
 
@@ -103,7 +109,32 @@ def _build_parser() -> argparse.ArgumentParser:
         action="append",
         help="Add VALUE to the falsy set (repeatable).",
     )
+    parser.add_argument(
+        "--show-config",
+        action="store_true",
+        help="Print the effective configuration and exit.",
+    )
     return parser
+
+
+def _print_config(args: argparse.Namespace) -> None:
+    """Print the effective configuration, reflecting any CLI overrides."""
+    config = load_config()
+    effective_truthy, effective_falsy = _resolve(
+        config_truthy=config.effective_truthy,
+        config_falsy=config.effective_falsy,
+        truthy=args.truthy,
+        falsy=args.falsy,
+        extend_truthy=args.extend_truthy,
+        extend_falsy=args.extend_falsy,
+    )
+    effective_strict = args.strict if args.strict is not None else config.strict
+
+    print(f"config file: {config.source_path or 'none'}")
+    print(f"strict:      {str(effective_strict).lower()}")
+    print(f"warn:        {str(config.warn).lower()}")
+    print(f"truthy:      {', '.join(sorted(effective_truthy))}")
+    print(f"falsy:       {', '.join(sorted(effective_falsy))}")
 
 
 def main() -> None:
@@ -111,6 +142,21 @@ def main() -> None:
     # All coercion logic lives in _core.py; this function is pure I/O plumbing.
     parser = _build_parser()
     args = parser.parse_args()
+
+    if args.show_config:
+        conflicting = (
+            args.var is not None
+            or args.value is not None
+            or args.print_result
+            or args.default
+        )
+        if conflicting:
+            parser.error(
+                "--show-config is mutually exclusive with VAR_NAME, --value, "
+                "--print, and --default"
+            )
+        _print_config(args)
+        sys.exit(0)
 
     # --value and VAR_NAME are mutually exclusive. Using argparse's built-in
     # add_mutually_exclusive_group would place them in a separate usage section,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -274,3 +274,79 @@ class TestCLIValueSets:
             monkeypatch=monkeypatch,
         )
         assert code == 1
+
+
+# ---------------------------------------------------------------------------
+# --show-config flag
+# ---------------------------------------------------------------------------
+
+
+class TestCLIShowConfig:
+    def test_no_config_file_prints_defaults(self, monkeypatch, tmp_path, capsys):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("ENVBOOL_NO_CONFIG", "1")
+        _reset_config()
+        code = run_cli("--show-config", monkeypatch=monkeypatch)
+        assert code == 0
+        out = capsys.readouterr().out
+        assert "config file: none" in out
+        assert "strict:      false" in out
+        assert "warn:        false" in out
+
+    def test_config_file_path_and_values_printed(self, monkeypatch, tmp_path, capsys):
+        config_file = tmp_path / "envbool.toml"
+        config_file.write_text('strict = true\nwarn = true\ntruthy = ["yep"]\n')
+        monkeypatch.chdir(tmp_path)
+        _reset_config()
+        code = run_cli("--show-config", monkeypatch=monkeypatch)
+        assert code == 0
+        out = capsys.readouterr().out
+        assert str(config_file) in out
+        assert "strict:      true" in out
+        assert "warn:        true" in out
+        assert "truthy:      yep" in out
+
+    def test_cli_strict_flag_overrides_printed_strict(
+        self, monkeypatch, tmp_path, capsys
+    ):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("ENVBOOL_NO_CONFIG", "1")
+        _reset_config()
+        code = run_cli("--show-config", "--strict", monkeypatch=monkeypatch)
+        assert code == 0
+        out = capsys.readouterr().out
+        assert "strict:      true" in out
+
+    def test_cli_extend_truthy_reflected_in_printed_truthy(
+        self, monkeypatch, tmp_path, capsys
+    ):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("ENVBOOL_NO_CONFIG", "1")
+        _reset_config()
+        code = run_cli(
+            "--show-config", "--extend-truthy", "maybe", monkeypatch=monkeypatch
+        )
+        assert code == 0
+        out = capsys.readouterr().out
+        assert "maybe" in out
+
+    def test_show_config_with_var_name_exits_2(self, monkeypatch, capsys):
+        monkeypatch.setenv("TEST_VAR", "true")
+        code = run_cli("--show-config", "TEST_VAR", monkeypatch=monkeypatch)
+        assert code == 2
+        assert "mutually exclusive" in capsys.readouterr().err
+
+    def test_show_config_with_value_exits_2(self, monkeypatch, capsys):
+        code = run_cli("--show-config", "--value", "yes", monkeypatch=monkeypatch)
+        assert code == 2
+        assert "mutually exclusive" in capsys.readouterr().err
+
+    def test_show_config_with_print_exits_2(self, monkeypatch, capsys):
+        code = run_cli("--show-config", "--print", monkeypatch=monkeypatch)
+        assert code == 2
+        assert "mutually exclusive" in capsys.readouterr().err
+
+    def test_show_config_with_default_exits_2(self, monkeypatch, capsys):
+        code = run_cli("--show-config", "--default", monkeypatch=monkeypatch)
+        assert code == 2
+        assert "mutually exclusive" in capsys.readouterr().err


### PR DESCRIPTION
## Summary
- Adds `--show-config` to print the effective config (config file path, strict, warn, truthy, falsy) and exit, closing #2.
- Reflects `--strict`/`--truthy`/`--falsy`/`--extend-truthy`/`--extend-falsy` overrides when passed alongside it, so users can preview exactly what a real invocation would resolve to.
- Mutually exclusive with `VAR_NAME`, `--value`, `--print`, and `--default` (exit 2 if combined) since those imply evaluating a value rather than inspecting config.

Closes #2

## Test plan
- [x] `uv run pytest tests/test_cli.py -v` — all pass, including new `TestCLIShowConfig` cases
- [x] `uv run pytest --cov=envbool` — 100% coverage maintained
- [x] `uv run ruff check src/ tests/` / `uv run ruff format --check src/ tests/`
- [x] `uv run ty check src/`
- [x] Manual check: `envbool --show-config` with and without an `envbool.toml` present, output matches the format in the issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)