### PR TITLE
feat: add --warn flag to CLI

### DIFF
--- a/src/envbool/_cli.py
+++ b/src/envbool/_cli.py
@@ -13,7 +13,8 @@ Exit codes:
   1  -- falsy or unset/empty
   2  -- error (unrecognized value in strict mode, bad arguments, multi-line stdin)
 
-Omitting --strict defers to the config file setting (default: lenient).
+Omitting --strict or --warn defers to the config file setting (default:
+lenient, no warnings).
 
 Value sets: --truthy/--falsy (repeatable) replace the truthy/falsy set;
 --extend-truthy/--extend-falsy (repeatable) add to it. Mirrors ruff's
@@ -27,9 +28,9 @@ exclusive with VAR_NAME, --value, --print, and --default.
 Public surface:
     main()  -- entry point registered as the "envbool" command
 """
-# --strict uses default=None rather than False so an absent flag passes None
-# through to envbool()/to_bool(), which then defers to the loaded config
-# instead of overriding a config-level strict = true with False.
+# --strict and --warn use default=None rather than False so an absent flag
+# passes None through to envbool()/to_bool(), which then defers to the loaded
+# config instead of overriding a config-level strict/warn = true with False.
 
 __all__ = ["main"]
 
@@ -70,6 +71,13 @@ def _build_parser() -> argparse.ArgumentParser:
         # store_true with default=None gives: flag present -> True, absent -> None.
         default=None,
         help="Raise error on unrecognized values.",
+    )
+    parser.add_argument(
+        "--warn",
+        action="store_true",
+        # None so an absent flag defers to config rather than overriding it with False.
+        default=None,
+        help="Log a warning on unrecognized values.",
     )
     parser.add_argument(
         "--default",
@@ -129,10 +137,11 @@ def _print_config(args: argparse.Namespace) -> None:
         extend_falsy=args.extend_falsy,
     )
     effective_strict = args.strict if args.strict is not None else config.strict
+    effective_warn = args.warn if args.warn is not None else config.warn
 
     print(f"config file: {config.source_path or 'none'}")
     print(f"strict:      {str(effective_strict).lower()}")
-    print(f"warn:        {str(config.warn).lower()}")
+    print(f"warn:        {str(effective_warn).lower()}")
     print(f"truthy:      {', '.join(sorted(effective_truthy))}")
     print(f"falsy:       {', '.join(sorted(effective_falsy))}")
 
@@ -176,6 +185,7 @@ def main() -> None:
             result = to_bool(
                 args.value,
                 strict=args.strict,
+                warn=args.warn,
                 default=args.default,
                 **value_set_kwargs,
             )
@@ -183,6 +193,7 @@ def main() -> None:
             result = envbool(
                 args.var,
                 strict=args.strict,
+                warn=args.warn,
                 default=args.default,
                 **value_set_kwargs,
             )
@@ -200,6 +211,7 @@ def main() -> None:
             result = to_bool(
                 raw,
                 strict=args.strict,
+                warn=args.warn,
                 default=args.default,
                 **value_set_kwargs,
             )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -61,6 +61,27 @@ class TestCLIExitCodes:
 
 
 # ---------------------------------------------------------------------------
+# --warn flag
+# ---------------------------------------------------------------------------
+
+
+class TestCLIWarnFlag:
+    def test_warn_flag_logs_warning_on_unrecognized_value(self, monkeypatch, caplog):
+        monkeypatch.setenv("TEST_VAR", "maybe")
+        with caplog.at_level("WARNING"):
+            code = run_cli("TEST_VAR", "--warn", monkeypatch=monkeypatch)
+        assert code == 1
+        assert "maybe" in caplog.text
+
+    def test_no_warn_flag_logs_nothing(self, monkeypatch, caplog):
+        monkeypatch.setenv("TEST_VAR", "maybe")
+        with caplog.at_level("WARNING"):
+            code = run_cli("TEST_VAR", monkeypatch=monkeypatch)
+        assert code == 1
+        assert caplog.text == ""
+
+
+# ---------------------------------------------------------------------------
 # --value flag
 # ---------------------------------------------------------------------------
 
@@ -197,6 +218,15 @@ class TestCLIConfigIntegration:
         code = run_cli("TEST_VAR", "--strict", monkeypatch=monkeypatch)
         assert code == 2
 
+    def test_config_warn_propagates(self, monkeypatch, tmp_path, caplog):
+        (tmp_path / "envbool.toml").write_text("warn = true\n")
+        monkeypatch.chdir(tmp_path)
+        _reset_config()
+        monkeypatch.setenv("TEST_VAR", "maybe")
+        with caplog.at_level("WARNING"):
+            run_cli("TEST_VAR", monkeypatch=monkeypatch)
+        assert "maybe" in caplog.text
+
     def test_config_extend_truthy_propagates(self, monkeypatch, tmp_path):
         (tmp_path / "envbool.toml").write_text('extend_truthy = ["enabled"]\n')
         monkeypatch.chdir(tmp_path)
@@ -316,6 +346,15 @@ class TestCLIShowConfig:
         assert code == 0
         out = capsys.readouterr().out
         assert "strict:      true" in out
+
+    def test_cli_warn_flag_overrides_printed_warn(self, monkeypatch, tmp_path, capsys):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("ENVBOOL_NO_CONFIG", "1")
+        _reset_config()
+        code = run_cli("--show-config", "--warn", monkeypatch=monkeypatch)
+        assert code == 0
+        out = capsys.readouterr().out
+        assert "warn:        true" in out
 
     def test_cli_extend_truthy_reflected_in_printed_truthy(
         self, monkeypatch, tmp_path, capsys


### PR DESCRIPTION
## Summary
- Adds a `--warn` flag to the CLI that mirrors `--strict`: omitted defers to the config file's `warn` setting, present forces `warn=True` and logs a WARNING on unrecognized values in lenient mode.
- `--show-config` now prints the effective `warn` value (config + CLI override), consistent with how it already handles `strict`.

Closes #3

## Test plan
- [x] `uv run pytest --cov=envbool` — 100% coverage, all passing
- [x] `uv run ruff check` / `ruff format --check` / `uv run ty check` — clean