### PR TITLE
fix: handle ConfigError gracefully in the CLI

### DIFF
--- a/src/envbool/_cli.py
+++ b/src/envbool/_cli.py
@@ -40,7 +40,7 @@ import sys
 from envbool._config import load_config
 from envbool._core import _resolve, to_bool
 from envbool._env import envbool
-from envbool.exceptions import InvalidBoolValueError
+from envbool.exceptions import ConfigError, InvalidBoolValueError
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -152,27 +152,6 @@ def main() -> None:
     parser = _build_parser()
     args = parser.parse_args()
 
-    if args.show_config:
-        conflicting = (
-            args.var is not None
-            or args.value is not None
-            or args.print_result
-            or args.default
-        )
-        if conflicting:
-            parser.error(
-                "--show-config is mutually exclusive with VAR_NAME, --value, "
-                "--print, and --default"
-            )
-        _print_config(args)
-        sys.exit(0)
-
-    # --value and VAR_NAME are mutually exclusive. Using argparse's built-in
-    # add_mutually_exclusive_group would place them in a separate usage section,
-    # which makes the help text harder to read, so we validate manually instead.
-    if args.value is not None and args.var is not None:
-        parser.error("VAR_NAME and --value are mutually exclusive")
-
     value_set_kwargs = {
         "truthy": args.truthy,
         "falsy": args.falsy,
@@ -180,7 +159,33 @@ def main() -> None:
         "extend_falsy": args.extend_falsy,
     }
 
+    # Both --show-config and the coercion calls below trigger config-file loading,
+    # so a malformed config can raise ConfigError from either path. A single error
+    # boundary around both keeps that failure a clean "error: ..." exit rather than
+    # an uncaught traceback. parser.error() and sys.exit() raise SystemExit, which
+    # is not caught here and so propagates as intended.
     try:
+        if args.show_config:
+            conflicting = (
+                args.var is not None
+                or args.value is not None
+                or args.print_result
+                or args.default
+            )
+            if conflicting:
+                parser.error(
+                    "--show-config is mutually exclusive with VAR_NAME, --value, "
+                    "--print, and --default"
+                )
+            _print_config(args)
+            sys.exit(0)
+
+        # --value and VAR_NAME are mutually exclusive. Using argparse's built-in
+        # add_mutually_exclusive_group would place them in a separate usage section,
+        # which makes the help text harder to read, so we validate manually instead.
+        if args.value is not None and args.var is not None:
+            parser.error("VAR_NAME and --value are mutually exclusive")
+
         if args.value is not None:
             result = to_bool(
                 args.value,
@@ -218,7 +223,7 @@ def main() -> None:
         else:
             parser.print_usage(sys.stderr)
             sys.exit(2)
-    except InvalidBoolValueError as e:
+    except (InvalidBoolValueError, ConfigError) as e:
         print(f"error: {e}", file=sys.stderr)
         sys.exit(2)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -389,3 +389,39 @@ class TestCLIShowConfig:
         code = run_cli("--show-config", "--default", monkeypatch=monkeypatch)
         assert code == 2
         assert "mutually exclusive" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# Malformed config file handling
+# ---------------------------------------------------------------------------
+
+
+class TestCLIConfigError:
+    def test_malformed_config_on_var_lookup_exits_2(
+        self, monkeypatch, tmp_path, capsys
+    ):
+        # A malformed config file in the tree must surface as a clean CLI error
+        # (exit 2, message on stderr), not an uncaught traceback.
+        (tmp_path / "envbool.toml").write_text('strict = "yes"\n')
+        monkeypatch.chdir(tmp_path)
+        # A non-empty value is required: an unset/empty var short-circuits in
+        # to_bool() before config is ever loaded, so it would never hit the error.
+        monkeypatch.setenv("TEST_VAR", "true")
+        _reset_config()
+        code = run_cli("TEST_VAR", monkeypatch=monkeypatch)
+        assert code == 2
+        captured = capsys.readouterr()
+        assert "error" in captured.err.lower()
+        assert "Traceback" not in captured.err
+
+    def test_malformed_config_on_show_config_exits_2(
+        self, monkeypatch, tmp_path, capsys
+    ):
+        (tmp_path / "envbool.toml").write_text('strict = "yes"\n')
+        monkeypatch.chdir(tmp_path)
+        _reset_config()
+        code = run_cli("--show-config", monkeypatch=monkeypatch)
+        assert code == 2
+        captured = capsys.readouterr()
+        assert "error" in captured.err.lower()
+        assert "Traceback" not in captured.err


### PR DESCRIPTION
## Problem

A malformed config file anywhere in the directory tree caused **every**
`envbool` CLI invocation to crash with an uncaught `ConfigError` traceback and
exit `1`:

```console
$ envbool DEBUG   # with `strict = "yes"` in envbool.toml
Traceback (most recent call last):
  ...
envbool.exceptions.ConfigError: Config error in .../envbool.toml: 'strict' must be a boolean ...
```

Neither the `--show-config` path (`_print_config` → `load_config`) nor the
coercion calls (`to_bool`/`envbool` → `_get_config`) caught `ConfigError`, so it
propagated out of `main()`.

## Fix

Wrap both config-loading paths in a single error boundary that catches
`ConfigError` alongside the existing `InvalidBoolValueError`, printing a clean
`error: ...` message to stderr and exiting `2` — consistent with how the CLI
already reports strict-mode violations and bad arguments.

```console
$ envbool DEBUG   # with `strict = "yes"` in envbool.toml
error: Config error in .../envbool.toml: 'strict' must be a boolean (true or false), got 'str'
$ echo $?
2
```

`parser.error()` and `sys.exit()` raise `SystemExit`, which is deliberately not
caught by the new boundary and propagates as before.

## Tests

Added `TestCLIConfigError` with two cases (malformed config on a var lookup and
on `--show-config`). Both were confirmed to fail before the fix (uncaught
`ConfigError`) and pass after. The var-lookup case sets a non-empty value so it
actually reaches config loading — an unset/empty var short-circuits in
`to_bool()` first.

- [x] `just` passes (ruff format + lint, ty, pytest)
- [x] 260 tests pass at 100% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)