### PR TITLE
chore: release 0.1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "envbool"
-version = "0.1.1"
+version = "0.1.2"
 description = "A small Python library and CLI tool for coercing environment variables (and arbitrary strings) into boolean values."
 readme = "README.md"
 authors = [{ name = "Kyle O'Malley", email = "j.kyle.omalley@gmail.com" }]

--- a/uv.lock
+++ b/uv.lock
@@ -135,7 +135,7 @@ wheels = [
 
 [[package]]
 name = "envbool"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "platformdirs" },


### PR DESCRIPTION
## Release 0.1.2

Patch release bundling the work merged since 0.1.1:

- **fix:** the CLI now handles a malformed config file gracefully (`error: ...` + exit 2) instead of crashing with an uncaught `ConfigError` traceback (#10)
- **docs:** rewritten README and CONTRIBUTING (#9)

Bumps `version` to `0.1.2` via `uv version --bump patch` (updates `pyproject.toml` and `uv.lock`). Once merged to `main`, the CD workflow will detect that `0.1.2` is not yet on PyPI and publish it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)