### PR TITLE
chore: release 0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "envbool"
-version = "0.1.2"
+version = "0.2.0"
 description = "A small Python library and CLI tool for coercing environment variables (and arbitrary strings) into boolean values."
 readme = "README.md"
 authors = [{ name = "Kyle O'Malley", email = "j.kyle.omalley@gmail.com" }]

--- a/uv.lock
+++ b/uv.lock
@@ -135,7 +135,7 @@ wheels = [
 
 [[package]]
 name = "envbool"
-version = "0.1.2"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "platformdirs" },


### PR DESCRIPTION
## Release 0.2.0

Re-cut of the mis-numbered `0.1.2` release with the correct version number.

`0.1.2` was published as a patch, but it was the first release since `0.1.1` to ship new CLI features (`--truthy`/`--falsy`/`--extend-*` in #6, `--show-config` in #7, `--warn` in #8), which under semver warrants a **minor** bump. This PR bumps to `0.2.0` (via `uv version --bump minor`) so the version reflects the feature content.

Same content as `0.1.2`; that release is being retracted (GitHub release + tag deleted, PyPI version yanked).

Once merged, CD will publish `0.2.0` to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)