### PR TITLE
ci: guard against mis-numbered releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,78 @@ jobs:
 
       - name: Test
         run: uv run pytest
+
+  # Guards against mis-numbered releases: if a PR bumps the version, the bump
+  # must be large enough for the conventional-commit types merged since the last
+  # release tag (a feat -> minor, a breaking change -> major). Non-release PRs
+  # (no version change) pass trivially. Born from 0.1.2, which shipped features
+  # as a patch and had to be retracted in favor of 0.2.0.
+  version-guard:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history + tags are needed to compare against the last release
+
+      - name: Verify version bump matches changes since last release
+        run: |
+          python3 - <<'PY'
+          import re
+          import subprocess
+          import sys
+          import tomllib
+
+
+          def git(*args: str) -> str:
+              return subprocess.run(
+                  ["git", *args], capture_output=True, text=True, check=True
+              ).stdout.strip()
+
+
+          with open("pyproject.toml", "rb") as fh:
+              version = tomllib.load(fh)["project"]["version"]
+          cur = tuple(int(p) for p in version.split("."))
+
+          tags = git("tag", "--list", "v[0-9]*", "--sort=-v:refname").split()
+          if not tags:
+              print("No release tag yet; nothing to compare against.")
+              sys.exit(0)
+          last = tags[0]
+          prev = tuple(int(p) for p in last.lstrip("v").split("."))
+
+          if cur == prev:
+              print(f"Version still {version} (== {last}); not a release PR. OK.")
+              sys.exit(0)
+
+          log = git("log", f"{last}..HEAD", "--format=%s%n%b")
+          breaking = bool(re.search(r"(?m)^\w+(\([^)]*\))?!:", log)) or (
+              "BREAKING CHANGE" in log
+          )
+          feat = bool(re.search(r"(?m)^feat(\([^)]*\))?!?:", log))
+
+          # In 0.x, a breaking change is a minor bump by convention, not a major one.
+          if breaking and prev[0] > 0:
+              required = "major"
+          elif breaking or feat:
+              required = "minor"
+          else:
+              required = "patch"
+
+          if cur[0] != prev[0]:
+              actual = "major"
+          elif cur[1] != prev[1]:
+              actual = "minor"
+          else:
+              actual = "patch"
+
+          rank = {"patch": 0, "minor": 1, "major": 2}
+          if rank[actual] < rank[required]:
+              print(
+                  f"::error::{version} is a {actual} bump over {last}, but commits "
+                  f"since {last} require a {required} bump. "
+                  f"Run 'uv version --bump {required}'."
+              )
+              sys.exit(1)
+          print(f"OK: {actual} bump for {version} satisfies the required {required}.")
+          PY

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,37 @@ you'd rather not install `just`.
 
 CI runs the full check suite against Python 3.11–3.14 on every pull request.
 
+## Releasing
+
+Releases are published to PyPI automatically: the CD workflow fires when CI
+passes on `main` and publishes whenever `pyproject.toml`'s version isn't already
+on PyPI. So a release is just a version bump merged to `main`.
+
+Choose the bump from the changes since the **last release tag**, not just your
+latest work:
+
+```bash
+git log "$(git describe --tags --abbrev=0)"..HEAD --oneline
+```
+
+Map the conventional-commit types in that range to a [semver](https://semver.org/)
+bump and apply it with `uv`:
+
+| Changes since last release | Bump | Command |
+| --- | --- | --- |
+| Any `feat:` | minor | `uv version --bump minor` |
+| Only `fix:` / `docs:` / `chore:` | patch | `uv version --bump patch` |
+| A breaking change (`feat!:`, `BREAKING CHANGE`) | major¹ | `uv version --bump major` |
+
+¹ While the project is pre-1.0, breaking changes are released as a **minor**
+bump per semver's 0.x convention.
+
+Open the bump as its own PR. The `version-guard` CI job enforces this: it fails
+any release PR whose bump is too small for the commits since the last release
+(for example, shipping a `feat:` in a patch). Features merged to `main` without
+a release accumulate, so the bump must account for all of them — not just the
+most recent change.
+
 ## License
 
 By contributing, you agree that your contributions are licensed under the


### PR DESCRIPTION
## Why

`0.1.2` shipped three feature PRs (`--truthy`/`--falsy`/`--extend-*`, `--show-config`, `--warn`) as a **patch** and had to be retracted in favor of `0.2.0`. This adds an automated guard so that can't happen again.

## What

- **`version-guard` CI job** (runs on PRs): if a PR changes the version in `pyproject.toml`, the bump must be large enough for the conventional-commit types merged since the last release tag — a `feat:` requires a minor bump, a breaking change a major (a minor while pre-1.0). Non-release PRs (no version change) pass trivially. On failure it prints the exact `uv version --bump <level>` to run.
- **CONTRIBUTING "Releasing" section**: documents the auto-publish flow and a bump-selection table, stressing that you derive the bump from `git log <last-tag>..HEAD` (all unreleased changes), not just your latest work.

## Validation

Tested the guard logic against five scenarios in throwaway repos — all behaved correctly:

| Scenario | Expected | Result |
| --- | --- | --- |
| patch bump + `feat:` present (the 0.1.2 bug) | fail | ✅ fails |
| minor bump + `feat:` present | pass | ✅ |
| patch bump + only `fix:`/`docs:` | pass | ✅ |
| breaking change + minor bump (0.x) | pass | ✅ |
| `feat:` + patch bump | fail | ✅ fails |

After merge I'll add `version-guard` to the branch-protection required checks so release PRs can't bypass it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)