### PR TITLE
feat: add public reload_config()

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ Set `ENVBOOL_NO_CONFIG=1` to skip config discovery entirely.
 | `envbool(var, **opts)` | Read an environment variable and return `bool`. |
 | `to_bool(value, **opts)` | Coerce a string to `bool`. |
 | `load_config()` | Load and return the active `EnvBoolConfig` (cached). |
+| `reload_config()` | Discard the cache, re-read the config file, and return the fresh `EnvBoolConfig`. |
 | `EnvBoolConfig` | Frozen dataclass: `strict`, `warn`, `effective_truthy`, `effective_falsy`, `source_path`. |
 | `DEFAULT_TRUTHY` | `frozenset` of the built-in truthy strings. |
 | `DEFAULT_FALSY` | `frozenset` of the built-in falsy strings. |

--- a/src/envbool/__init__.py
+++ b/src/envbool/__init__.py
@@ -12,6 +12,7 @@ Available names:
     envbool()             -- read an env var and coerce to bool (primary API)
     to_bool()             -- coerce an arbitrary string to bool (no os.environ)
     load_config()         -- inspect or preload the process-level config cache
+    reload_config()       -- discard the cache and re-read the config file
     EnvBoolConfig         -- frozen dataclass returned by load_config()
     DEFAULT_TRUTHY        -- built-in truthy set (frozenset)
     DEFAULT_FALSY         -- built-in falsy set (frozenset)
@@ -23,7 +24,7 @@ Available names:
 # surface can be reshaped without breaking imports. Do not import from _core,
 # _env, _config, _cli, or _defaults directly.
 
-from envbool._config import EnvBoolConfig, load_config
+from envbool._config import EnvBoolConfig, load_config, reload_config
 from envbool._core import to_bool
 from envbool._defaults import DEFAULT_FALSY, DEFAULT_TRUTHY
 from envbool._env import envbool
@@ -38,5 +39,6 @@ __all__ = [
     "InvalidBoolValueError",
     "envbool",
     "load_config",
+    "reload_config",
     "to_bool",
 ]

--- a/src/envbool/_config.py
+++ b/src/envbool/_config.py
@@ -26,7 +26,7 @@ import platformdirs
 from envbool._defaults import DEFAULT_FALSY, DEFAULT_TRUTHY
 from envbool.exceptions import ConfigError
 
-__all__ = ["EnvBoolConfig", "load_config"]
+__all__ = ["EnvBoolConfig", "load_config", "reload_config"]
 
 _logger = logging.getLogger(__name__)
 
@@ -87,6 +87,28 @@ def load_config() -> EnvBoolConfig:
         ConfigError: If a config file is found but malformed or has invalid values.
     """
     return _get_config()
+
+
+def reload_config() -> EnvBoolConfig:
+    """Force a re-read of the config file, replacing the cached config.
+
+    ``load_config()`` caches for the lifetime of the process, so a config file
+    that is written or edited after the first lookup is never picked up. Call
+    this to discard the cache and reload from disk -- useful in long-running
+    processes (workers, servers, notebooks) that change config at runtime.
+
+    The clear-and-reload happens atomically under the cache lock so concurrent
+    readers never observe a momentarily empty cache.
+
+    Returns:
+        The freshly loaded EnvBoolConfig, now installed as the cached instance.
+
+    Raises:
+        ConfigError: If a config file is found but malformed or has invalid values.
+    """
+    with _cache.lock:
+        _cache.config = _load_config_from_disk()
+        return _cache.config
 
 
 def _get_config() -> EnvBoolConfig:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -592,6 +592,36 @@ class TestResetConfig:
 
 
 # ---------------------------------------------------------------------------
+# reload_config
+# ---------------------------------------------------------------------------
+
+
+class TestReloadConfig:
+    def test_returns_envbool_config(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        assert isinstance(envbool.reload_config(), EnvBoolConfig)
+
+    def test_picks_up_on_disk_change(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "envbool.toml").write_text("strict = false\n")
+        first = load_config()
+        assert first.strict is False
+
+        # Rewriting the file is invisible until the cache is refreshed; unlike
+        # _reset_config(), reload_config() both clears and reloads in one call.
+        (tmp_path / "envbool.toml").write_text("strict = true\n")
+        second = envbool.reload_config()
+        assert second.strict is True
+        # Subsequent reads see the refreshed config without another disk hit.
+        assert load_config() is second
+
+    def test_updates_the_shared_cache(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        reloaded = envbool.reload_config()
+        assert _get_config() is reloaded
+
+
+# ---------------------------------------------------------------------------
 # Thread safety
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

Adds a public `reload_config()` that discards the cached config and re-reads the config file, returning the fresh `EnvBoolConfig`.

## Why

`load_config()` caches for the lifetime of the process, so a config file written or edited after the first lookup is never picked up. The only way to clear the cache was the private, test-only `_reset_config()`. Long-running processes (workers, servers, notebooks) that change config at runtime now have a supported way to refresh it.

The clear-and-reload happens atomically under the existing cache lock, so concurrent readers never observe a momentarily empty cache.

## Tests

- `TestReloadConfig`: returns an `EnvBoolConfig`, picks up an on-disk change, and updates the shared cache.
- Full suite green, 100% coverage maintained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)