### PR TITLE
feat: add required=True / --required to raise on unset env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Set `ENVBOOL_NO_CONFIG=1` to skip config discovery entirely.
 | `DEFAULT_FALSY` | `frozenset` of the built-in falsy strings. |
 | `EnvBoolError` | Base class for every exception the library raises. |
 | `InvalidBoolValueError` | Raised in strict mode for unrecognized values. Also a `ValueError`. |
+| `MissingEnvVarError` | Raised by `envbool(required=True)` when the variable is unset. Also a `KeyError`. |
 | `ConfigError` | Raised when a config file is malformed. |
 
 `envbool()` and `to_bool()` share the same keyword-only options:
@@ -230,6 +231,10 @@ Set `ENVBOOL_NO_CONFIG=1` to skip config discovery entirely.
 | `warn` | `bool \| None` | `None` | Log a warning on unrecognized values (`None` defers to config). |
 | `truthy` / `falsy` | `Iterable[str] \| None` | `None` | **Replace** the effective set. |
 | `extend_truthy` / `extend_falsy` | `Iterable[str] \| None` | `None` | **Extend** the effective set. |
+
+`envbool()` also accepts `required` (`bool`, default `False`): when `True`, a
+variable that is unset raises `MissingEnvVarError` before `default` is applied. A
+variable set to an empty string counts as present and still uses `default`.
 
 ## Advanced topics
 

--- a/src/envbool/__init__.py
+++ b/src/envbool/__init__.py
@@ -17,6 +17,7 @@ Available names:
     DEFAULT_FALSY         -- built-in falsy set (frozenset)
     EnvBoolError          -- base exception for all envbool errors
     InvalidBoolValueError -- raised in strict mode for unrecognized values
+    MissingEnvVarError    -- raised by envbool(required=True) when a var is unset
     ConfigError           -- raised for malformed or unreadable config files
 """
 # All implementation lives in private underscore-prefixed modules so the public
@@ -27,7 +28,12 @@ from envbool._config import EnvBoolConfig, load_config
 from envbool._core import to_bool
 from envbool._defaults import DEFAULT_FALSY, DEFAULT_TRUTHY
 from envbool._env import envbool
-from envbool.exceptions import ConfigError, EnvBoolError, InvalidBoolValueError
+from envbool.exceptions import (
+    ConfigError,
+    EnvBoolError,
+    InvalidBoolValueError,
+    MissingEnvVarError,
+)
 
 __all__ = [
     "DEFAULT_FALSY",
@@ -36,6 +42,7 @@ __all__ = [
     "EnvBoolConfig",
     "EnvBoolError",
     "InvalidBoolValueError",
+    "MissingEnvVarError",
     "envbool",
     "load_config",
     "to_bool",

--- a/src/envbool/_cli.py
+++ b/src/envbool/_cli.py
@@ -11,7 +11,8 @@ Input source (first match wins):
 Exit codes:
   0  -- truthy
   1  -- falsy or unset/empty
-  2  -- error (unrecognized value in strict mode, bad arguments, multi-line stdin)
+  2  -- error (unrecognized value in strict mode, unset VAR_NAME with --required,
+        bad arguments, multi-line stdin)
 
 Omitting --strict or --warn defers to the config file setting (default:
 lenient, no warnings).
@@ -40,7 +41,7 @@ import sys
 from envbool._config import load_config
 from envbool._core import _resolve, to_bool
 from envbool._env import envbool
-from envbool.exceptions import ConfigError, InvalidBoolValueError
+from envbool.exceptions import ConfigError, InvalidBoolValueError, MissingEnvVarError
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -85,6 +86,13 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         default=False,
         help="Default value if unset/empty (default: false).",
+    )
+    parser.add_argument(
+        "--required",
+        "-r",
+        action="store_true",
+        default=False,
+        help="Exit 2 if VAR_NAME is not set in the environment.",
     )
     parser.add_argument(
         "--print",
@@ -146,18 +154,78 @@ def _print_config(args: argparse.Namespace) -> None:
     print(f"falsy:       {', '.join(sorted(effective_falsy))}")
 
 
-def main() -> None:
-    """Parse arguments, resolve the input source, and exit with the appropriate code."""
-    # All coercion logic lives in _core.py; this function is pure I/O plumbing.
-    parser = _build_parser()
-    args = parser.parse_args()
+def _coerce_from_source(
+    parser: argparse.ArgumentParser, args: argparse.Namespace
+) -> bool:
+    """Resolve the input source (--value, VAR_NAME, or stdin) and coerce it to bool.
 
+    Validates the mutually exclusive source flags, then dispatches to the matching
+    coercion call. Exits via parser.error()/sys.exit() for usage errors; the
+    coercion exceptions propagate to main()'s single error boundary.
+    """
     value_set_kwargs = {
         "truthy": args.truthy,
         "falsy": args.falsy,
         "extend_truthy": args.extend_truthy,
         "extend_falsy": args.extend_falsy,
     }
+
+    # --value and VAR_NAME are mutually exclusive. Using argparse's built-in
+    # add_mutually_exclusive_group would place them in a separate usage section,
+    # which makes the help text harder to read, so we validate manually instead.
+    if args.value is not None and args.var is not None:
+        parser.error("VAR_NAME and --value are mutually exclusive")
+
+    # --required only governs the env-var lookup; a literal --value always
+    # has a value, so combining them is a usage error rather than a no-op.
+    if args.required and args.value is not None:
+        parser.error("--required and --value are mutually exclusive")
+
+    if args.value is not None:
+        return to_bool(
+            args.value,
+            strict=args.strict,
+            warn=args.warn,
+            default=args.default,
+            **value_set_kwargs,
+        )
+    if args.var is not None:
+        return envbool(
+            args.var,
+            strict=args.strict,
+            warn=args.warn,
+            default=args.default,
+            required=args.required,
+            **value_set_kwargs,
+        )
+    if not sys.stdin.isatty():
+        # Non-TTY stdin means the user piped or redirected input. Strip surrounding
+        # whitespace (handles the trailing newline echo adds) then reject anything
+        # with an embedded newline -- only a single value is meaningful here.
+        raw = sys.stdin.read().strip()
+        if "\n" in raw:
+            print(
+                "error: stdin must contain a single value, not multiple lines",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        return to_bool(
+            raw,
+            strict=args.strict,
+            warn=args.warn,
+            default=args.default,
+            **value_set_kwargs,
+        )
+
+    parser.print_usage(sys.stderr)
+    sys.exit(2)
+
+
+def main() -> None:
+    """Parse arguments, resolve the input source, and exit with the appropriate code."""
+    # All coercion logic lives in _core.py; this function is pure I/O plumbing.
+    parser = _build_parser()
+    args = parser.parse_args()
 
     # Both --show-config and the coercion calls below trigger config-file loading,
     # so a malformed config can raise ConfigError from either path. A single error
@@ -180,50 +248,8 @@ def main() -> None:
             _print_config(args)
             sys.exit(0)
 
-        # --value and VAR_NAME are mutually exclusive. Using argparse's built-in
-        # add_mutually_exclusive_group would place them in a separate usage section,
-        # which makes the help text harder to read, so we validate manually instead.
-        if args.value is not None and args.var is not None:
-            parser.error("VAR_NAME and --value are mutually exclusive")
-
-        if args.value is not None:
-            result = to_bool(
-                args.value,
-                strict=args.strict,
-                warn=args.warn,
-                default=args.default,
-                **value_set_kwargs,
-            )
-        elif args.var is not None:
-            result = envbool(
-                args.var,
-                strict=args.strict,
-                warn=args.warn,
-                default=args.default,
-                **value_set_kwargs,
-            )
-        elif not sys.stdin.isatty():
-            # Non-TTY stdin means the user piped or redirected input. Strip surrounding
-            # whitespace (handles the trailing newline echo adds) then reject anything
-            # with an embedded newline -- only a single value is meaningful here.
-            raw = sys.stdin.read().strip()
-            if "\n" in raw:
-                print(
-                    "error: stdin must contain a single value, not multiple lines",
-                    file=sys.stderr,
-                )
-                sys.exit(2)
-            result = to_bool(
-                raw,
-                strict=args.strict,
-                warn=args.warn,
-                default=args.default,
-                **value_set_kwargs,
-            )
-        else:
-            parser.print_usage(sys.stderr)
-            sys.exit(2)
-    except (InvalidBoolValueError, ConfigError) as e:
+        result = _coerce_from_source(parser, args)
+    except (InvalidBoolValueError, ConfigError, MissingEnvVarError) as e:
         print(f"error: {e}", file=sys.stderr)
         sys.exit(2)
 

--- a/src/envbool/_env.py
+++ b/src/envbool/_env.py
@@ -14,12 +14,14 @@ import os
 from collections.abc import Iterable
 
 from envbool._core import to_bool
+from envbool.exceptions import MissingEnvVarError
 
 
 def envbool(
     var: str,
     *,
     default: bool = False,
+    required: bool = False,
     strict: bool | None = None,
     warn: bool | None = None,
     truthy: Iterable[str] | None = None,
@@ -32,6 +34,9 @@ def envbool(
     Args:
         var: Environment variable name.
         default: Returned when the variable is unset or empty.
+        required: When True, raise if the variable is not set at all. A truly
+            unset var raises before `default` is considered; a var set to an
+            empty string is "present" and still coerces via `default`.
         strict: Raise on unrecognized values. None defers to config (default False).
         warn: Log a warning on unrecognized values. None defers to config
             (default False).
@@ -45,7 +50,17 @@ def envbool(
 
     Raises:
         InvalidBoolValueError: In strict mode when the value is unrecognized.
+        MissingEnvVarError: When required=True and the variable is unset.
     """
+    # `required` distinguishes "absent from the environment" from "set but empty"
+    # -- membership, not the value, so VAR= (empty) is treated as present. This
+    # check precedes the default-handling below so an unset required var raises
+    # instead of silently falling back to `default`.
+    if required and var not in os.environ:
+        err = MissingEnvVarError(f"Required environment variable {var} is not set")
+        err.var = var
+        raise err
+
     # Missing var becomes "" so to_bool treats it the same as an empty value,
     # returning `default` rather than raising or treating absence as a distinct state.
     value = os.environ.get(var, "")

--- a/src/envbool/exceptions.py
+++ b/src/envbool/exceptions.py
@@ -8,6 +8,7 @@ which predates envbool adoption keeps working without changes.
 Hierarchy:
     EnvBoolError(Exception)
         InvalidBoolValueError(EnvBoolError, ValueError)
+        MissingEnvVarError(EnvBoolError, KeyError)
         ConfigError(EnvBoolError)
 """
 
@@ -42,6 +43,24 @@ class InvalidBoolValueError(EnvBoolError, ValueError):
     # so callers can inspect exactly what was expected without re-running resolution.
     truthy: frozenset[str]
     falsy: frozenset[str]
+
+
+class MissingEnvVarError(EnvBoolError, KeyError):
+    """Raised by envbool(var, required=True) when var is not set in the environment.
+
+    Dual inheritance with KeyError mirrors the InvalidBoolValueError(ValueError)
+    pattern: a missing os.environ lookup naturally raises KeyError, so existing
+    ``except KeyError`` handlers keep working after a codebase adopts envbool.
+
+    Only a truly-unset variable triggers this -- a variable set to an empty
+    string is "present" and coerces normally via the caller's default.
+    """
+
+    # Set by the raising code after construction (see InvalidBoolValueError for
+    # why attributes live here rather than in __init__).
+
+    # Name of the environment variable that was required but not set.
+    var: str
 
 
 class ConfigError(EnvBoolError):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -61,6 +61,40 @@ class TestCLIExitCodes:
 
 
 # ---------------------------------------------------------------------------
+# --required flag
+# ---------------------------------------------------------------------------
+
+
+class TestCLIRequiredFlag:
+    def test_unset_required_exits_2(self, monkeypatch, capsys):
+        monkeypatch.delenv("TEST_VAR", raising=False)
+        code = run_cli("TEST_VAR", "--required", monkeypatch=monkeypatch)
+        assert code == 2
+        assert "error" in capsys.readouterr().err.lower()
+
+    def test_short_flag_unset_exits_2(self, monkeypatch):
+        monkeypatch.delenv("TEST_VAR", raising=False)
+        code = run_cli("TEST_VAR", "-r", monkeypatch=monkeypatch)
+        assert code == 2
+
+    def test_set_truthy_required_exits_0(self, monkeypatch):
+        monkeypatch.setenv("TEST_VAR", "true")
+        code = run_cli("TEST_VAR", "--required", monkeypatch=monkeypatch)
+        assert code == 0
+
+    def test_set_falsy_required_exits_1(self, monkeypatch):
+        monkeypatch.setenv("TEST_VAR", "false")
+        code = run_cli("TEST_VAR", "--required", monkeypatch=monkeypatch)
+        assert code == 1
+
+    def test_required_with_value_is_rejected(self, monkeypatch, capsys):
+        # A literal --value always has a value, so --required is meaningless there.
+        code = run_cli("--required", "--value", "true", monkeypatch=monkeypatch)
+        assert code == 2
+        assert "mutually exclusive" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
 # --warn flag
 # ---------------------------------------------------------------------------
 

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -7,7 +7,7 @@ import pytest
 from envbool._config import _reset_config
 from envbool._defaults import DEFAULT_FALSY, DEFAULT_TRUTHY
 from envbool._env import envbool
-from envbool.exceptions import InvalidBoolValueError
+from envbool.exceptions import InvalidBoolValueError, MissingEnvVarError
 
 # ---------------------------------------------------------------------------
 # Unset / empty
@@ -34,6 +34,45 @@ class TestEnvBoolUnset:
     def test_whitespace_only_returns_custom_default(self, monkeypatch):
         monkeypatch.setenv("TEST_VAR", "   ")
         assert envbool("TEST_VAR", default=True) is True
+
+
+# ---------------------------------------------------------------------------
+# required=True
+# ---------------------------------------------------------------------------
+
+
+class TestEnvBoolRequired:
+    def test_unset_required_raises(self, monkeypatch):
+        monkeypatch.delenv("TEST_VAR", raising=False)
+        with pytest.raises(MissingEnvVarError):
+            envbool("TEST_VAR", required=True)
+
+    def test_unset_required_raises_before_default_applies(self, monkeypatch):
+        # default is irrelevant for a truly-unset required var -- it raises
+        # rather than falling back to the default value.
+        monkeypatch.delenv("TEST_VAR", raising=False)
+        with pytest.raises(MissingEnvVarError):
+            envbool("TEST_VAR", required=True, default=True)
+
+    def test_error_carries_var_name(self, monkeypatch):
+        monkeypatch.delenv("TEST_VAR", raising=False)
+        with pytest.raises(MissingEnvVarError) as exc_info:
+            envbool("TEST_VAR", required=True)
+        assert exc_info.value.var == "TEST_VAR"
+
+    def test_empty_string_is_not_missing(self, monkeypatch):
+        # Set-but-empty is present, so required does not fire; normal default
+        # handling applies and the value coerces to False.
+        monkeypatch.setenv("TEST_VAR", "")
+        assert envbool("TEST_VAR", required=True) is False
+
+    def test_set_value_coerces_normally(self, monkeypatch):
+        monkeypatch.setenv("TEST_VAR", "true")
+        assert envbool("TEST_VAR", required=True) is True
+
+    def test_required_false_keeps_lenient_unset_behavior(self, monkeypatch):
+        monkeypatch.delenv("TEST_VAR", raising=False)
+        assert envbool("TEST_VAR", required=False) is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -9,7 +9,12 @@ from pathlib import Path
 
 import pytest
 
-from envbool.exceptions import ConfigError, EnvBoolError, InvalidBoolValueError
+from envbool.exceptions import (
+    ConfigError,
+    EnvBoolError,
+    InvalidBoolValueError,
+    MissingEnvVarError,
+)
 
 
 class TestEnvBoolError:
@@ -109,6 +114,49 @@ class TestInvalidBoolValueError:
         err = InvalidBoolValueError("bad")
         err.falsy = frozenset()
         assert err.falsy == frozenset()
+
+
+class TestMissingEnvVarError:
+    """Dual-inheritance: EnvBoolError + KeyError.
+
+    Must be catchable as either parent so existing ``except KeyError``
+    handlers (the natural type for a missing os.environ lookup) keep working.
+    """
+
+    # --- inheritance ---
+
+    def test_is_envbool_error(self):
+        assert issubclass(MissingEnvVarError, EnvBoolError)
+
+    def test_is_key_error(self):
+        assert issubclass(MissingEnvVarError, KeyError)
+
+    def test_not_value_error(self):
+        assert not issubclass(MissingEnvVarError, ValueError)
+
+    def test_mro_order(self):
+        """EnvBoolError should appear before KeyError in the MRO."""
+        mro = MissingEnvVarError.__mro__
+        envbool_idx = mro.index(EnvBoolError)
+        key_idx = mro.index(KeyError)
+        assert envbool_idx < key_idx
+
+    # --- raises as parent types ---
+
+    def test_raises_as_key_error(self):
+        with pytest.raises(KeyError):
+            raise MissingEnvVarError("missing")
+
+    def test_raises_as_envbool_error(self):
+        with pytest.raises(EnvBoolError):
+            raise MissingEnvVarError("missing")
+
+    # --- annotated attributes ---
+
+    def test_var_attribute(self):
+        err = MissingEnvVarError("missing")
+        err.var = "MY_VAR"
+        assert err.var == "MY_VAR"
 
 
 class TestConfigError:


### PR DESCRIPTION
## What

Adds a `required` option to `envbool()` (and `--required`/`-r` to the CLI) that turns a missing environment variable into an error instead of silently using the default.

- `envbool("X", required=True)` raises the new **`MissingEnvVarError`** when `X` is absent from the environment.
- The check is on *membership*, not value: `X=` (set but empty) counts as present and still coerces via `default`.
- An unset required var raises *before* `default` is considered.

## Why

`envbool("X")` collapsed "unset" and "set-but-empty" into the same `default`, so callers who genuinely need "the var was not provided at all" had no way to detect it. This fills that gap while preserving the "always returns `bool`, never `None`" guarantee.

## Design notes

- `MissingEnvVarError(EnvBoolError, KeyError)` mirrors the existing `InvalidBoolValueError(EnvBoolError, ValueError)` precedent — a missing `os.environ` lookup naturally raises `KeyError`, so existing `except KeyError` handlers keep working. Carries a `var` attribute.
- `required` lives only on `envbool()` (env-specific); `to_bool()` is unchanged.
- CLI: `--required` exits 2 when unset, and is rejected with `--value` (a literal always has a value). `main()`'s input-source dispatch was extracted to `_coerce_from_source()` to stay under the complexity limit.

## Tests

- `TestEnvBoolRequired`, `TestMissingEnvVarError`, `TestCLIRequiredFlag`.
- Full suite green, 100% coverage maintained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)