### PR TITLE
test: add property-based tests for to_bool()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ build-backend = "uv_build"
 
 [dependency-groups]
 dev = [
+    "hypothesis>=6.155.5",
     "pre-commit>=4.5.1",
     "pytest>=9.0.3",
     "pytest-cov>=7.1.0",

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -1,0 +1,82 @@
+"""Property-based tests for to_bool().
+
+100% line/branch coverage proves every line ran, not that behaviors hold across
+the whole input space. These hypothesis properties pin the invariants a coercion
+function must satisfy for *any* input, independent of the specific examples in the
+other test modules. They never touch os.environ -- to_bool() is pure.
+"""
+
+from hypothesis import assume, given
+from hypothesis import strategies as st
+
+from envbool import to_bool
+from envbool._defaults import DEFAULT_FALSY, DEFAULT_TRUTHY
+
+# Printable ASCII keeps the case-folding property free of unicode edge cases
+# (e.g. characters whose .upper()/.lower() are not clean round-trips).
+_ASCII_PRINTABLE = st.text(st.characters(min_codepoint=32, max_codepoint=126))
+
+_WHITESPACE = st.sampled_from(["", " ", "\t", "  ", "\n", " \t "])
+
+
+def _noise(value: str, data) -> str:
+    """Wrap a token in hypothesis-drawn surrounding whitespace and mixed case.
+
+    Drawing from `data` (rather than the `random` module) keeps examples
+    reproducible and shrinkable. to_bool() normalizes by stripping then
+    lowercasing, so neither change may affect the outcome -- exactly what the
+    membership properties assert.
+    """
+    cased = "".join(data.draw(st.sampled_from([c.upper(), c.lower()])) for c in value)
+    return f"{data.draw(_WHITESPACE)}{cased}{data.draw(_WHITESPACE)}"
+
+
+@given(st.text())
+def test_always_returns_exactly_bool(value):
+    # Not just truthy/falsy -- the public contract is the bool type itself.
+    assert type(to_bool(value)) is bool
+
+
+@given(st.text())
+def test_surrounding_whitespace_never_changes_result(value):
+    assert to_bool(value) == to_bool(f" \t\n{value}\n\t ")
+
+
+@given(_ASCII_PRINTABLE)
+def test_case_never_changes_result(value):
+    assert to_bool(value) == to_bool(value.swapcase())
+
+
+@given(st.sampled_from(sorted(DEFAULT_TRUTHY)), st.data())
+def test_truthy_members_are_true_under_noise(token, data):
+    assert to_bool(_noise(token, data)) is True
+
+
+@given(st.sampled_from(sorted(DEFAULT_FALSY)), st.data())
+def test_falsy_members_are_false_under_noise(token, data):
+    assert to_bool(_noise(token, data)) is False
+
+
+@given(st.text(alphabet=" \t\n\r\f\v"), st.booleans())
+def test_blank_input_returns_default(value, default):
+    # Anything that normalizes to empty is "unset" -- the caller's default wins.
+    assert to_bool(value, default=default) is default
+
+
+@given(_ASCII_PRINTABLE)
+def test_unrecognized_is_false_in_lenient_mode(value):
+    normalized = value.strip().lower()
+    # Skip blanks (governed by default) and any recognized token.
+    assume(normalized)
+    assume(normalized not in DEFAULT_TRUTHY)
+    assume(normalized not in DEFAULT_FALSY)
+    assert to_bool(value) is False
+
+
+@given(st.lists(_ASCII_PRINTABLE, min_size=1, max_size=5))
+def test_every_custom_truthy_token_coerces_true(tokens):
+    # Replacing the truthy set must make every one of its members coerce True,
+    # even one that collides with a default falsy token (truthy wins on overlap).
+    assume(all(t.strip().lower() for t in tokens))  # blanks return default instead
+    for token in tokens:
+        assert to_bool(token, truthy=tokens) is True

--- a/uv.lock
+++ b/uv.lock
@@ -143,6 +143,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "hypothesis" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -155,6 +156,7 @@ requires-dist = [{ name = "platformdirs", specifier = ">=4.9.6" }]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "hypothesis", specifier = ">=6.155.5" },
     { name = "pre-commit", specifier = ">=4.5.1" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
@@ -169,6 +171,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
+]
+
+[[package]]
+name = "hypothesis"
+version = "6.155.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b6/da/7e6cca4f0ad6b2f3a2380d72993ad3482c8ecb126f0908af26d2427455a1/hypothesis-6.155.5.tar.gz", hash = "sha256:f7f8f803e05a69cd70399b07ed89a89b673c9ff3530977c4a768ed3acb702169", size = 478083, upload-time = "2026-06-18T19:23:04.405Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/db/04b7cfc3cc6d49eecc6a390e61c5b941a0a32a98884fdf0701228a9b9c4f/hypothesis-6.155.5-py3-none-any.whl", hash = "sha256:b0eb5645f4c962dffdafef36d05329aa704a5322ee1273495fa98d5a986daf70", size = 544524, upload-time = "2026-06-18T19:23:02.975Z" },
 ]
 
 [[package]]
@@ -371,6 +385,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
     { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
     { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Adds `tests/test_properties.py` — hypothesis property-based tests for `to_bool()` — and `hypothesis` as a dev dependency.

## Why

The suite already has 100% line+branch coverage, but that proves every line *ran*, not that the coercion invariants hold across the whole input space. A pure coercion function is the ideal candidate for property testing.

## Properties pinned

- Result is **always exactly `bool`** for any string.
- Surrounding whitespace never changes the result.
- Case never changes the result.
- Every default truthy/falsy token maps to the right bool under randomized case + whitespace.
- Blank (whitespace-only) input returns the caller's `default`.
- Any unrecognized, non-blank token is `False` in lenient mode.
- Every member of a custom `truthy=` replacement set coerces `True` (including overlaps, where truthy wins).

Noise is drawn from hypothesis's `data` strategy rather than the `random` module, so failures stay reproducible and shrinkable.

## Verification

- `tests/test_properties.py`: 8 properties pass.
- Full suite green, 100% coverage maintained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)