### PR TITLE
chore: release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-06-18
+
 ### Added
 
 - `reload_config()`: a public function that discards the cached config and
@@ -79,7 +81,8 @@ Initial release.
 - CLI with exit-code semantics (`0` truthy, `1` falsy) and a `--print` flag.
 - TOML config support (`envbool.toml` or `[tool.envbool]` in `pyproject.toml`).
 
-[Unreleased]: https://github.com/jkomalley/envbool/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/jkomalley/envbool/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/jkomalley/envbool/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/jkomalley/envbool/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/jkomalley/envbool/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/jkomalley/envbool/releases/tag/v0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "envbool"
-version = "0.2.0"
+version = "0.3.0"
 description = "A small Python library and CLI tool for coercing environment variables (and arbitrary strings) into boolean values."
 readme = "README.md"
 authors = [{ name = "Kyle O'Malley", email = "j.kyle.omalley@gmail.com" }]

--- a/uv.lock
+++ b/uv.lock
@@ -135,7 +135,7 @@ wheels = [
 
 [[package]]
 name = "envbool"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "platformdirs" },


### PR DESCRIPTION
Release PR for **v0.3.0** — the first release since 0.2.0.

## Version

`0.2.0` → `0.3.0` (minor). Two new features since v0.2.0 require at least a minor bump under semver, which the CI version-guard enforces.

## Changes since 0.2.0

### Added
- **`reload_config()`** (#14) — discard the cached config and re-read the config file, for long-running processes that change config at runtime.
- **`required` / `--required`** (#15) — `envbool(required=True)` (and CLI `-r`) raises the new **`MissingEnvVarError`** when a variable is unset. A var set to an empty string counts as present and still uses `default`.
- **`python -m envbool`** (#17) — works as an alias for the installed console script.

### Internal / quality
- Property-based tests for `to_bool()` (#16) and subprocess-level CLI smoke tests (#17).
- `Development Status` classifier bumped to `4 - Beta` (#18).

## This PR
- `pyproject.toml` + `uv.lock`: version `0.3.0`.
- `CHANGELOG.md`: moved the `Unreleased` entries under a dated `## [0.3.0] - 2026-06-18` heading and refreshed the compare links.

## Release mechanics
On merge to `main`, CD checks PyPI, builds, publishes `envbool 0.3.0`, tags `v0.3.0`, and opens a **draft** GitHub release to finalize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)