### PR TITLE
Fix MissingEnvVarError quoting and --required edge cases

### DIFF
--- a/src/envbool/_cli.py
+++ b/src/envbool/_cli.py
@@ -215,13 +215,17 @@ def _coerce_from_source(
                 file=sys.stderr,
             )
             sys.exit(2)
-        return to_bool(
-            raw,
-            strict=args.strict,
-            warn=args.warn,
-            default=args.default,
-            **value_set_kwargs,
-        )
+        # Empty stdin (e.g. `envbool </dev/null` under cron/CI with a forgotten
+        # VAR_NAME) is "no source applies", not "the value is empty" -- fall
+        # through to the usage/exit-2 path below rather than silently coercing.
+        if raw:
+            return to_bool(
+                raw,
+                strict=args.strict,
+                warn=args.warn,
+                default=args.default,
+                **value_set_kwargs,
+            )
 
     parser.print_usage(sys.stderr)
     sys.exit(2)

--- a/src/envbool/_cli.py
+++ b/src/envbool/_cli.py
@@ -181,6 +181,12 @@ def _coerce_from_source(
     if args.required and args.value is not None:
         parser.error("--required and --value are mutually exclusive")
 
+    # --required only makes sense against an env var lookup; reject it whenever
+    # there's no VAR_NAME to be "required" -- covers both the stdin-pipe path and
+    # the case where neither --value nor VAR_NAME nor stdin was given.
+    if args.required and args.var is None:
+        parser.error("--required requires VAR_NAME")
+
     if args.value is not None:
         return to_bool(
             args.value,
@@ -239,11 +245,12 @@ def main() -> None:
                 or args.value is not None
                 or args.print_result
                 or args.default
+                or args.required
             )
             if conflicting:
                 parser.error(
                     "--show-config is mutually exclusive with VAR_NAME, --value, "
-                    "--print, and --default"
+                    "--print, --default, and --required"
                 )
             _print_config(args)
             sys.exit(0)

--- a/src/envbool/exceptions.py
+++ b/src/envbool/exceptions.py
@@ -56,6 +56,11 @@ class MissingEnvVarError(EnvBoolError, KeyError):
     string is "present" and coerces normally via the caller's default.
     """
 
+    # KeyError.__str__ reprs its argument (e.g. `str(KeyError("x"))` == `"'x'"`),
+    # which would wrap every rendered message in stray quotes. Restore plain
+    # Exception formatting so `str(e)` and CLI/log output read cleanly.
+    __str__ = Exception.__str__
+
     # Set by the raising code after construction (see InvalidBoolValueError for
     # why attributes live here rather than in __init__).
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -225,6 +225,18 @@ class TestCLIStdin:
         code = run_cli("--strict", monkeypatch=monkeypatch, stdin_text="maybe\n")
         assert code == 2
 
+    def test_empty_stdin_exits_2_with_usage(self, monkeypatch, capsys):
+        code = run_cli(monkeypatch=monkeypatch, stdin_text="")
+        assert code == 2
+        captured = capsys.readouterr()
+        assert "usage" in captured.err.lower()
+
+    def test_whitespace_only_stdin_exits_2_with_usage(self, monkeypatch, capsys):
+        code = run_cli(monkeypatch=monkeypatch, stdin_text="   \n")
+        assert code == 2
+        captured = capsys.readouterr()
+        assert "usage" in captured.err.lower()
+
 
 # ---------------------------------------------------------------------------
 # No input (TTY, no args)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -93,6 +93,16 @@ class TestCLIRequiredFlag:
         assert code == 2
         assert "mutually exclusive" in capsys.readouterr().err
 
+    def test_required_with_stdin_is_rejected(self, monkeypatch, capsys):
+        code = run_cli("--required", monkeypatch=monkeypatch, stdin_text="true\n")
+        assert code == 2
+        assert "requires VAR_NAME" in capsys.readouterr().err
+
+    def test_required_with_no_source_is_rejected(self, monkeypatch, capsys):
+        code = run_cli("--required", monkeypatch=monkeypatch)
+        assert code == 2
+        assert "requires VAR_NAME" in capsys.readouterr().err
+
 
 # ---------------------------------------------------------------------------
 # --warn flag
@@ -421,6 +431,11 @@ class TestCLIShowConfig:
 
     def test_show_config_with_default_exits_2(self, monkeypatch, capsys):
         code = run_cli("--show-config", "--default", monkeypatch=monkeypatch)
+        assert code == 2
+        assert "mutually exclusive" in capsys.readouterr().err
+
+    def test_show_config_with_required_exits_2(self, monkeypatch, capsys):
+        code = run_cli("--show-config", "--required", monkeypatch=monkeypatch)
         assert code == 2
         assert "mutually exclusive" in capsys.readouterr().err
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -158,6 +158,13 @@ class TestMissingEnvVarError:
         err.var = "MY_VAR"
         assert err.var == "MY_VAR"
 
+    # --- message rendering ---
+
+    def test_str_has_no_extra_quotes(self):
+        """KeyError.__str__ reprs its arg; MissingEnvVarError must not inherit that."""
+        err = MissingEnvVarError("Required environment variable DEBUG is not set")
+        assert str(err) == "Required environment variable DEBUG is not set"
+
 
 class TestConfigError:
     """Raised for malformed config files. Not a ValueError."""


### PR DESCRIPTION
## Summary
- MissingEnvVarError.__str__ no longer wraps messages in stray quotes (KeyError.__str__ artifact).
- --required now rejects usage with no VAR_NAME (was silently ignored on the stdin and --show-config paths).
- Empty non-TTY stdin now prints usage and exits 2 instead of silently coercing "" to the default.

## Test plan
- [x] uv run pytest --cov=envbool (100% coverage)
- [x] uv run ruff check src/ tests/
- [x] uv run ty check src/