### PR TITLE
chore: release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.4.0] - YYYY-MM-DD
+## [0.4.0] - 2026-07-12
 
 ### Removed (breaking)
 


### PR DESCRIPTION
## Summary
- Sets the 0.4.0 release date in the CHANGELOG (version was already bumped in #22).
- 0.4.0 contents: set_defaults()/get_defaults()/reset_defaults() replacing config-file discovery; ConfigError/--show-config/reload_config/ENVBOOL_NO_CONFIG/platformdirs removed (zero-dependency); three CLI/exception bug fixes. See CHANGELOG for the migration note.

## Test plan
- [x] Docs-only change; CI runs the full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)